### PR TITLE
AI-549-Gmail Skills 'RemoveLabelFromEmail' method is missing all parameters.

### DIFF
--- a/DotNet/GMail/Templates/openapi.yaml
+++ b/DotNet/GMail/Templates/openapi.yaml
@@ -317,7 +317,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/RemoveLabelRequest"
+              $ref: "#/components/schemas/QueryEmailAndRemoveLabelRequest"
         required: true 
 ### /threads/remove_label_from_thread------------------------------------------ 
   $skillapproot/threads/remove_label_from_thread:


### PR DESCRIPTION
AI-549-Gmail Skills 'RemoveLabelFromEmail' method is missing all parameters.