### PR TITLE
Fix for AI-569

### DIFF
--- a/DotNet/GCalendar/Helpers/ValidationHelpers.cs
+++ b/DotNet/GCalendar/Helpers/ValidationHelpers.cs
@@ -140,8 +140,8 @@ namespace GCalendar.Helpers
                 RecurringEventId = item.RecurringEventId,
                 OriginalStartDateTime = Has(item.OriginalStartTime) ? (Has(item.OriginalStartTime.DateTime) ? item.OriginalStartTime.DateTime.ToString() : item.OriginalStartTime.Date.ToString()) : null,
                 OriginalStartTimeZone = Has(item.OriginalStartTime) ? item.OriginalStartTime.TimeZone : null,
-                AttendeesEmails = string.Join(",", item.Attendees.Select(attendee => attendee.Email))
-            };
+                AttendeesEmails = Has(item.Recurrence) ? string.Join(",", item.Attendees.Select(attendee => attendee.Email)) : null
+        };
         }
     }
 }


### PR DESCRIPTION
TriofoxAI - Web portal- Gcalendar skill does not give correct answer when ask it to find event for certain time
https://jira.hadroncloud.com:8443/browse/AI-569

For the prompt of getting events on a specific day using a prompt "get all my events for march 28th" there isn't really a code fix for the skills as its an issue with the assistant sending an incorrect date in 2023. 