### PR TITLE
AI-608-Calendar skill can not query the event with title

### DIFF
--- a/DotNet/GCalendar/Helpers/ValidationHelpers.cs
+++ b/DotNet/GCalendar/Helpers/ValidationHelpers.cs
@@ -140,8 +140,8 @@ namespace GCalendar.Helpers
                 RecurringEventId = item.RecurringEventId,
                 OriginalStartDateTime = Has(item.OriginalStartTime) ? (Has(item.OriginalStartTime.DateTime) ? item.OriginalStartTime.DateTime.ToString() : item.OriginalStartTime.Date.ToString()) : null,
                 OriginalStartTimeZone = Has(item.OriginalStartTime) ? item.OriginalStartTime.TimeZone : null,
-                AttendeesEmails = Has(item.Recurrence) ? string.Join(",", item.Attendees.Select(attendee => attendee.Email)) : null
-        };
+                AttendeesEmails = (Has(item.Recurrence) && Has(item.Attendees)) ? string.Join(",", item.Attendees.Select(attendee => attendee.Email)) : null
+            };
         }
     }
 }


### PR DESCRIPTION
Fixed unhandled exception when deserializing calendar event attendee data.